### PR TITLE
Change name for marketplace publishing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'Datadog Workflow Metrics'
-description: 'Reports data on the workflow to datadog'
+name: 'rS Datadog Workflow Metrics'
+description: 'Reports data on the workflow to datadog, by rewardStyle'
 inputs:
   datadog-metric-prefix:
     description: 'A prefix for your datadog metrics'


### PR DESCRIPTION
### This PR
- Changes the action's name in the metadata file (`action.yml`) to "rS Datadog Workflow Metrics"

#### Why?

- This repo was forked from https://github.com/scribd/github-action-datadog-reporting out of extreme caution, because in order to capture metrics (via oktokit), the action requires a GitHub token, and in order to publish metrics (via DataDog API), the action requires a DataDog token. Rather than directly use scribd's published action, we've decided to perform a direct fork, rename, republish, and use our own so as to maximize confidence that there will be NO unauthorized changes to the action going forward.
- ⚠️ Using random actions not maintained by a trusted authority / not using locked/vendored dependencies has the potential for a supply chain security incident.
- According to https://docs.github.com/en/actions/creating-actions/publishing-actions-in-github-marketplace, in order to publish an action on GitHub Marketplace,
  > The `name` in the action's metadata file must be unique.

#### Next Steps

1. Publish on marketplace: https://docs.github.com/en/actions/creating-actions/publishing-actions-in-github-marketplace#publishing-an-action
  - Private action repo use is possible, but not "official" yet from github: https://github.community/t/github-action-action-in-private-repository/16063/52 -- given that other users seem to incur headaches from these workarounds, I don't feel it's appropriate for us to invest in the effort at this time, versus publishing on the marketplace and understanding that we're the only intended users of the published action.
2. Update rewardStyle repos' workflows to reference _this_ action instead of scribd's.