### PR TITLE
feat: Add ruby setup step in composite action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'rS Datadog Workflow Metrics'
-description: 'Reports data on the workflow to datadog, by rewardStyle'
+name: 'LTK Datadog Workflow Metrics'
+description: 'Reports data on the workflow to datadog, by LTK'
 inputs:
   ruby-version:
     description: 'Version of ruby language to setup. Should be managed by this action, but can be overridden with a new version, or skipped if an empty string'

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'rS Datadog Workflow Metrics'
 description: 'Reports data on the workflow to datadog, by rewardStyle'
 inputs:
   ruby-version:
-    description: 'Version of ruby language to setup. Should be managed by this action, but can be overridden as an escape hatch'
+    description: 'Version of ruby language to setup. Should be managed by this action, but can be overridden with a new version, or skipped if an empty string'
     required: false
     default: 2.6
   datadog-metric-prefix:
@@ -24,8 +24,9 @@ runs:
   using: "composite"
   steps:
     - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{inputs.ruby-version}}
+      if: ${{inputs.ruby-version != ''}}
+      with:
+        ruby-version: ${{inputs.ruby-version}}
     - name: Install required libraries for gems
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,10 @@
 name: 'rS Datadog Workflow Metrics'
 description: 'Reports data on the workflow to datadog, by rewardStyle'
 inputs:
+  ruby-version:
+    description: 'Version of ruby language to setup. Should be managed by this action, but can be overridden as an escape hatch'
+    required: false
+    default: 2.6
   datadog-metric-prefix:
     description: 'A prefix for your datadog metrics'
     required: false
@@ -19,6 +23,9 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{inputs.ruby-version}}
     - name: Install required libraries for gems
       shell: bash
       run: |


### PR DESCRIPTION
Seems silly to require all consuming clients to setup a direct dependency for this action. Might even be a nice addition to include a default shared workflow that can be utilized with even less boilerplate, and more sane/managed defaults can be setup: https://docs.github.com/en/actions/learn-github-actions/reusing-workflows